### PR TITLE
Bug fix: Always get error "Socket closed by remote peer" after 'Error Domain=NSPOSIXErrorDomain Code=32 "Broken pipe"'

### DIFF
--- a/LibRabbitMQ-OC/Classes/AMQPConnection.m
+++ b/LibRabbitMQ-OC/Classes/AMQPConnection.m
@@ -105,13 +105,13 @@ NSString *const AMQPLibraryErrorDomain = @"AMQPLibraryErrorDomain";
     long loginTag = 0;
     self.mainChannel = [[AMQPChannel alloc] initWithChannel:(UInt16) loginTag connection:self];
     [self.channelMap setValue:self.mainChannel forKey:[NSString stringWithFormat:@"%ld", loginTag]];
+    BlockingQueue *blockingQueue = [BlockingQueue new];
+    [self.mainChannel enqueueRpc:blockingQueue];
+
     [self.socket writeData:
                     [NSData dataWithBytes:header length:sizeof(header)]
                withTimeout:self.writeTimeout
                        tag:loginTag];
-
-    BlockingQueue *blockingQueue = [BlockingQueue new];
-    [self.mainChannel enqueueRpc:blockingQueue];
     //first read
     [self.socket readDataWithTimeout:self.readTimeout tag:loginTag];
 


### PR DESCRIPTION
First, once hit

```
Connection disconnect Error Domain=NSPOSIXErrorDomain Code=32 "Broken pipe" UserInfo={NSLocalizedDescription=Broken pipe, NSLocalizedFailureReason=Error in write() function}
```

then, repeat

```
Connection Error Error Domain=AMQPLibraryErrorDomain Code=0 "Authentication Error" UserInfo={NSLocalizedDescription=Authentication Error}
Connection disconnect Error Domain=GCDAsyncSocketErrorDomain Code=7 "Socket closed by remote peer" UserInfo={NSLocalizedDescription=Socket closed by remote peer}
```
