### PR TITLE
didEnterBackground and ignore AMQP_FRAME_HEARTBEAT

### DIFF
--- a/LibRabbitMQ-OC/Classes/AMQPConnection.h
+++ b/LibRabbitMQ-OC/Classes/AMQPConnection.h
@@ -16,6 +16,7 @@
 
 @protocol AMQPConnectionLifecycleDelegate
 - (void)reconnectionSuccess:(NSString *)userName :(AMQPConnection *)connection;
+- (void)needReconnection:(NSError *)error;
 @end
 
 @interface AMQPConnection : NSObject <GCDAsyncSocketDelegate>
@@ -51,5 +52,5 @@
 
 - (void)startHeartbeat;
 
-- (void)shutdownHeartbeat;
+- (void)didEnterBackground;
 @end


### PR DESCRIPTION
- didEnterBackground
- needReconnection on AMQPConnectionLifecycleDelegate, when GCDAsyncSocketClosedError or Broke pipe
- AMQP_FRAME_HEARTBEAT from server can be ignored
